### PR TITLE
Fix memory leaks

### DIFF
--- a/obs-shaderfilter.c
+++ b/obs-shaderfilter.c
@@ -200,7 +200,7 @@ static void shader_filter_reload_effect(struct shader_filter_data *filter)
 	}
 
 	// Load text and build the effect from the template, if necessary.
-	const char *shader_text = NULL;
+	char *shader_text = NULL;
 	bool use_template =
 		!obs_data_get_bool(settings, "override_entire_effect");
 
@@ -214,12 +214,8 @@ static void shader_filter_reload_effect(struct shader_filter_data *filter)
 		use_template = true;
 	}
 
-	if (shader_text == NULL) {
-		shader_text = "";
-	}
-
 	size_t effect_header_length = strlen(effect_template_begin);
-	size_t effect_body_length = strlen(shader_text);
+	size_t effect_body_length = shader_text ? strlen(shader_text) : 0;
 	size_t effect_footer_length = strlen(effect_template_end);
 	size_t effect_buffer_total_size = effect_header_length +
 					  effect_body_length +
@@ -236,7 +232,10 @@ static void shader_filter_reload_effect(struct shader_filter_data *filter)
 		dstr_cat(&effect_text, effect_template_begin);
 	}
 
-	dstr_cat(&effect_text, shader_text);
+	if (shader_text) {
+		dstr_cat(&effect_text, shader_text);
+		bfree(shader_text);
+	}
 
 	if (use_template) {
 		dstr_cat(&effect_text, effect_template_end);
@@ -246,6 +245,8 @@ static void shader_filter_reload_effect(struct shader_filter_data *filter)
 	char *errors = NULL;
 
 	obs_enter_graphics();
+	if (filter->effect)
+		gs_effect_destroy(filter->effect);
 	filter->effect = gs_effect_create(effect_text.array, NULL, &errors);
 	obs_leave_graphics();
 
@@ -256,6 +257,8 @@ static void shader_filter_reload_effect(struct shader_filter_data *filter)
 		     "[obs-shaderfilter] Unable to create effect. Errors returned from parser:\n%s",
 		     (errors == NULL || strlen(errors) == 0 ? "(None)"
 							    : errors));
+		bfree(errors);
+		goto end;
 	}
 
 	// Store references to the new effect's parameters.
@@ -303,6 +306,9 @@ static void shader_filter_reload_effect(struct shader_filter_data *filter)
 			cached_data->param = param;
 		}
 	}
+
+end:
+	obs_data_release(settings);
 }
 
 static const char *shader_filter_get_name(void *unused)
@@ -340,6 +346,11 @@ static void *shader_filter_create(obs_data_t *settings, obs_source_t *source)
 static void shader_filter_destroy(void *data)
 {
 	struct shader_filter_data *filter = data;
+
+	obs_enter_graphics();
+	if (filter->effect)
+		gs_effect_destroy(filter->effect);
+	obs_leave_graphics();
 
 	dstr_free(&filter->last_path);
 	da_free(filter->stored_param_list);


### PR DESCRIPTION
### Description

Correctly release allocated memories.
Also skip processing the shader if `gs_effect_create` returns NULL.

### Motivation and Context

OBS reported memory leaks like below.
```
Number of memory leaks: 49
```

Just FYI, I traced the memory leaks with my custom OBS Studio.
https://github.com/obsproject/obs-studio/compare/master...norihiro:bmem-trace-memory-leak

### How Has This Been Tested?

Tested on my custom build on Linux (Fedora 34).

Preparation:
1. Start OBS
2. Add the filter to a scene.
3. Exit OBS

When testing:
1. Start OBS with a scene collection that has the filter attached to a scene
2. Open the property and modify some text in the shader.
3. Exit OBS
4. Check the number of memory leaks.

The log shows no memory leaks as below.
```
info: Number of memory leaks: 0
```

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
