### PR TITLE
Feature/improved input fields

### DIFF
--- a/data/examples/repeat.effect
+++ b/data/examples/repeat.effect
@@ -15,7 +15,9 @@ uniform float rand_f;
 
 uniform float alpha = 1.0;
 uniform float copies = 4.0;
-uniform string notes = 'copies, use a number that has a square root. Alpha adjusts the alpha level of the copies (recommend 0.5-2.0 recommend)';
+uniform string notes<
+    string widget_type = "info";
+> = 'copies, use a number that has a square root. Alpha adjusts the alpha level of the copies (recommend 0.5-2.0 recommend)';
 
 sampler_state def_sampler {
 	Filter   = Linear;

--- a/obs-shaderfilter.c
+++ b/obs-shaderfilter.c
@@ -786,7 +786,8 @@ static obs_properties_t *shader_filter_properties(void *data)
 					props, param_name, display_name.array,
 					OBS_COMBO_TYPE_LIST,
 					OBS_COMBO_FORMAT_INT);
-				for (int i = 0; i < param->option_values.num; i++) {
+				for (size_t i = 0; i < param->option_values.num;
+				     i++) {
 					obs_property_list_add_int(
 						plist, option_labels[i].array,
 						options[i]);

--- a/obs-shaderfilter.c
+++ b/obs-shaderfilter.c
@@ -434,49 +434,45 @@ static void shader_filter_reload_effect(struct shader_filter_data *filter)
 							gs_effect_get_default_val(
 								annotation));
 				} else if (strcmp(info.name, "minimum") == 0) {
-					switch (info.type) {
-					case GS_SHADER_PARAM_FLOAT:
+					if (info.type ==
+					    GS_SHADER_PARAM_FLOAT) {
 						cached_data->minimum.f =
 							*(float *)gs_effect_get_default_val(
 								annotation);
-						break;
-					case GS_SHADER_PARAM_INT:
+					} else if (info.type ==
+						   GS_SHADER_PARAM_INT) {
 						cached_data->minimum.i =
 							*(int *)gs_effect_get_default_val(
 								annotation);
-						break;
 					}
 				} else if (strcmp(info.name, "maximum") == 0) {
-					switch (info.type) {
-					case GS_SHADER_PARAM_FLOAT:
+					if (info.type ==
+					    GS_SHADER_PARAM_FLOAT) {
 						cached_data->maximum.f =
 							*(float *)gs_effect_get_default_val(
 								annotation);
-						break;
-					case GS_SHADER_PARAM_INT:
+					} else if (info.type ==
+						   GS_SHADER_PARAM_INT) {
 						cached_data->maximum.i =
 							*(int *)gs_effect_get_default_val(
 								annotation);
-						break;
 					}
 				} else if (strcmp(info.name, "step") == 0) {
-					switch (info.type) {
-					case GS_SHADER_PARAM_FLOAT:
+					if (info.type ==
+					    GS_SHADER_PARAM_FLOAT) {
 						cached_data->step.f =
 							*(float *)gs_effect_get_default_val(
 								annotation);
-						break;
-					case GS_SHADER_PARAM_INT:
+					} else if (info.type ==
+						   GS_SHADER_PARAM_INT) {
 						cached_data->step.i =
 							*(int *)gs_effect_get_default_val(
 								annotation);
-						break;
 					}
 				} else if (strncmp(info.name, "option_", 7) ==
 					   0) {
 					int id = atoi(info.name + 7);
-					switch (info.type) {
-					case GS_SHADER_PARAM_INT: {
+					if (info.type == GS_SHADER_PARAM_INT) {
 						int val =
 							*(int *)gs_effect_get_default_val(
 								annotation);
@@ -485,9 +481,9 @@ static void shader_filter_reload_effect(struct shader_filter_data *filter)
 								->option_values,
 							id);
 						*cd = val;
-						break;
-					}
-					case GS_SHADER_PARAM_STRING: {
+
+					} else if (info.type ==
+						   GS_SHADER_PARAM_STRING) {
 						struct dstr val = {0};
 						dstr_copy(
 							&val,
@@ -498,8 +494,6 @@ static void shader_filter_reload_effect(struct shader_filter_data *filter)
 								->option_labels,
 							id);
 						*cs = val;
-						break;
-					}
 					}
 				}
 			}

--- a/obs-shaderfilter.c
+++ b/obs-shaderfilter.c
@@ -17,7 +17,6 @@
 #include <string.h>
 
 #include <util/threading.h>
-#include <windows.h>
 
 /* clang-format off */
 

--- a/obs-shaderfilter.c
+++ b/obs-shaderfilter.c
@@ -753,8 +753,8 @@ static obs_properties_t *shader_filter_properties(void *data)
 			} else {
 				obs_properties_add_float(props, param_name,
 							 display_name.array,
-							 -FLT_MAX, FLT_MAX,
-							 0.000001);
+							 range_min, range_max,
+							 step);
 			}
 			break;
 		}
@@ -789,7 +789,8 @@ static obs_properties_t *shader_filter_properties(void *data)
 			} else {
 				obs_properties_add_int(props, param_name,
 						       display_name.array,
-						       INT_MIN, INT_MAX, 1);
+						       range_min, range_max,
+						       step);
 			}
 			break;
 		}
@@ -817,9 +818,16 @@ static obs_properties_t *shader_filter_properties(void *data)
 				shader_filter_texture_file_filter, NULL);
 			break;
 		case GS_SHADER_PARAM_STRING:
-			obs_properties_add_text(props, param_name,
-						display_name.array,
-						OBS_TEXT_MULTILINE);
+			if (widget_type != NULL &&
+			    strcmp(widget_type, "info") == 0) {
+				obs_properties_add_text(props, param_name,
+							display_name.array,
+							OBS_TEXT_INFO);
+			} else {
+				obs_properties_add_text(props, param_name,
+							display_name.array,
+							OBS_TEXT_MULTILINE);
+			}
 			break;
 		default:;
 		}

--- a/obs-shaderfilter.c
+++ b/obs-shaderfilter.c
@@ -87,8 +87,8 @@ struct effect_param_data {
 	struct dstr display_name;
 	struct dstr widget_type;
 	struct dstr description;
-	DARRAY(int) option_values;		// Does this get free'd?
-	DARRAY(struct dstr) option_labels;	// Does this get free'd?
+	DARRAY(int) option_values;
+	DARRAY(struct dstr) option_labels;
 
 	enum gs_shader_param_type type;
 	gs_eparam_t *param;
@@ -185,18 +185,18 @@ static unsigned int rand_interval(unsigned int min, unsigned int max)
 	return min + (r / buckets);
 }
 
-static char* load_shader_from_file(const char *file_name) // add input of visited files
+static char *
+load_shader_from_file(const char *file_name) // add input of visited files
 {
 
 	char *file_ptr = os_quick_read_utf8_file(file_name);
 	if (file_ptr == NULL)
 		return NULL;
 	char *file = bstrdup(os_quick_read_utf8_file(file_name));
-	char **lines =
-		strlist_split(file, '\n', true);
+	char **lines = strlist_split(file, '\n', true);
 	struct dstr shader_file;
 	dstr_init(&shader_file);
-	
+
 	size_t line_i = 0;
 	while (lines[line_i] != NULL) {
 		char *line = lines[line_i];
@@ -207,7 +207,7 @@ static char* load_shader_from_file(const char *file_name) // add input of visite
 			const size_t length = pos - file_name + 1;
 			struct dstr include_path = {0};
 			dstr_ncopy(&include_path, file_name, length);
-			char *start = strchr(line, '"')+1;
+			char *start = strchr(line, '"') + 1;
 			char *end = strrchr(line, '"');
 
 			dstr_ncat(&include_path, start, end - start);
@@ -418,14 +418,17 @@ static void shader_filter_reload_effect(struct shader_filter_data *filter)
 							gs_effect_get_default_val(
 								annotation));
 				} else if (strcmp(info.name, "label") == 0 &&
-				    info.type == GS_SHADER_PARAM_STRING) {
+					   info.type ==
+						   GS_SHADER_PARAM_STRING) {
 					dstr_copy(
 						&cached_data->display_name,
 						(const char *)
 							gs_effect_get_default_val(
 								annotation));
-				} else if (strcmp(info.name, "widget_type") == 0 &&
-				    info.type == GS_SHADER_PARAM_STRING) {
+				} else if (strcmp(info.name, "widget_type") ==
+						   0 &&
+					   info.type ==
+						   GS_SHADER_PARAM_STRING) {
 					dstr_copy(
 						&cached_data->widget_type,
 						(const char *)
@@ -470,18 +473,15 @@ static void shader_filter_reload_effect(struct shader_filter_data *filter)
 								annotation);
 						break;
 					}
-				} else if (strncmp(info.name, "option_", 7) == 0) {
-					char b[100];
-					strcpy(b, info.name);
-					char *token = strtok(b, "_");
-					token = strtok(NULL, "_");
-					int id = atoi(token);
+				} else if (strncmp(info.name, "option_", 7) ==
+					   0) {
+					int id = atoi(info.name + 7);
 					switch (info.type) {
 					case GS_SHADER_PARAM_INT: {
 						int val =
 							*(int *)gs_effect_get_default_val(
 								annotation);
-						int* cd = da_insert_new(
+						int *cd = da_insert_new(
 							cached_data
 								->option_values,
 							id);
@@ -494,7 +494,7 @@ static void shader_filter_reload_effect(struct shader_filter_data *filter)
 							&val,
 							(const char *)gs_effect_get_default_val(
 								annotation));
-						struct dstr* cs = da_insert_new(
+						struct dstr *cs = da_insert_new(
 							cached_data
 								->option_labels,
 							id);
@@ -733,9 +733,9 @@ static obs_properties_t *shader_filter_properties(void *data)
 			dstr_ncat(&display_name, param_name, param->name.len);
 			dstr_replace(&display_name, "_", " ");
 		} else {
-			dstr_ncat(&display_name, label, param->display_name.len);
+			dstr_ncat(&display_name, label,
+				  param->display_name.len);
 		}
-
 
 		switch (param->type) {
 		case GS_SHADER_PARAM_BOOL:
@@ -752,7 +752,8 @@ static obs_properties_t *shader_filter_properties(void *data)
 				step = 0.0001;
 			}
 			obs_properties_remove_by_name(props, param_name);
-			if (widget_type != NULL && strcmp(widget_type, "slider") == 0) {
+			if (widget_type != NULL &&
+			    strcmp(widget_type, "slider") == 0) {
 				obs_properties_add_float_slider(
 					props, param_name, display_name.array,
 					range_min, range_max, step);
@@ -872,7 +873,6 @@ static void shader_filter_update(void *data, obs_data_t *settings)
 		obs_source_t *source = NULL;
 		dstr_ncat(&display_name, param_name, param->name.len);
 		dstr_replace(&display_name, "_", " ");
-
 
 		switch (param->type) {
 		case GS_SHADER_PARAM_BOOL:


### PR DESCRIPTION
This PR adds optional minimum, maximum, step size, and widget type annotations to input fields.  For example:

```
// Contrast from -1.0 to 1.0
uniform float Contrast<
  string label = "Contrast Adjustment";
  string widget_type = "slider";
  float minimum = -1.0;
  float maximum = 1.0;
  float step = 0.01;
> = 0.0;
```
Will add a slider that has a minimum of -1.0, maximum of 1.0, and a step size of 0.01.  Also adds a drop-down select widget for integer fields, e.g.:
```
uniform int SelectTest<
  string label = "Int Select";
  string widget_type = "select";
  int    option_0_value = 0;
  string option_0_label = "First";
  int    option_1_value = 1;
  string option_1_label = "Second";
  int    option_2_value = 3;
  string option_2_label = "Third";
> = 3;
```

PR also adds a preprocessing step for HLSL files allowing for `#include "../relative/path/to/file.effect"` to include an external hlsl file.  Currently `#include` doesn't check for circular includes.