### PR TITLE
Fix ascii shader from data/examples

### DIFF
--- a/data/examples/ascii.shader
+++ b/data/examples/ascii.shader
@@ -58,8 +58,8 @@ float2 mod(float2 x, float2 y)
 
 float4 mainImage( VertData v_in ) : TARGET
 {
-    float2 iResolution = uv_size*uv_scale;
-    float2 pix = v_in.pos.xy;
+    float2 iResolution = uv_size;
+    float2 pix = v_in.uv * iResolution;
     float4 c = image.Sample(textureSampler, floor(pix/float2(scale*8.0,scale*8.0))*float2(scale*8.0,scale*8.0)/iResolution.xy);
 
     float gray = 0.3 * c.r + 0.59 * c.g + 0.11 * c.b;


### PR DESCRIPTION
Hello I noticed on my system the ASCII filter was broken (it would just remove completely the output image) with the latest version.
So I fixed it. Can you please confirm that indeed this fixes it and potentially merge it?

---

## Issue? #93 

>  The ascii.shader was making everything transparent when loaded in OBS.

 The shader was using incorrect coordinate types:
  - Line 62: Used `v_in.pos.xy` (screen-space pixel coordinates)
  - Line 61: Used `uv_size*uv_scale` for resolution calculation

  I assume it worked in OBS/obs-shaderfilter versions before ~2023, but broke after updates to the plugin's vertex data handling most probably.

## Solution

Updated the shader to use proper texture coordinates:
  - Line 62: Changed to `v_in.uv * iResolution` (converts UV coordinates 0-1 to pixel space)
  - Line 61: Changed to `uv_size` (correct resolution reference)

Cheers and good end of the year,
pulgamecanica

<img width="980" height="652" alt="image" src="https://github.com/user-attachments/assets/3bee3dc0-4e02-4129-abb8-56ab3ec436d6" />
